### PR TITLE
Changed jcontentConfig label

### DIFF
--- a/src/org/openstreetmap/josm/plugins/tofix/TofixDialog.java
+++ b/src/org/openstreetmap/josm/plugins/tofix/TofixDialog.java
@@ -169,7 +169,7 @@ public class TofixDialog extends ToggleDialog implements ActionListener {
             jcontenTasks.add(valuePanel);
 
             //add title to download
-            jcontenConfig.add(new Label(tr("Size to download in Sq.m")));
+            jcontenConfig.add(new Label(tr("Set download area (m²)")));
 
             //Add Slider to download
             slider.setMinorTickSpacing(2);


### PR DESCRIPTION
Changed the jcontenConfig label message from `Size to download in Sq.m` to `Set download area (m²)`
